### PR TITLE
Remove libxtend header files from biolibc Makefile

### DIFF
--- a/Makefile.depend
+++ b/Makefile.depend
@@ -1,9 +1,7 @@
-bed.o: bed.c bed.h biolibc.h gff.h ../local/include/xtend.h \
-  ../local/include/xtend-protos.h dsv.h
+bed.o: bed.c bed.h biolibc.h gff.h dsv.h
 	${CC} -c ${CFLAGS} bed.c
 
-biolibc.o: biolibc.c ../local/include/xtend.h \
-  ../local/include/xtend-protos.h biolibc.h
+biolibc.o: biolibc.c biolibc.h
 	${CC} -c ${CFLAGS} biolibc.c
 
 chromosome-name-cmp.o: chromosome-name-cmp.c biolibc.h
@@ -12,19 +10,16 @@ chromosome-name-cmp.o: chromosome-name-cmp.c biolibc.h
 dsv.o: dsv.c dsv.h biolibc.h
 	${CC} -c ${CFLAGS} dsv.c
 
-gff.o: gff.c gff.h biolibc.h ../local/include/xtend.h \
-  ../local/include/xtend-protos.h bed.h dsv.h
+gff.o: gff.c gff.h biolibc.h bed.h dsv.h
 	${CC} -c ${CFLAGS} gff.c
 
 plist.o: plist.c plist.h biolibc.h
 	${CC} -c ${CFLAGS} plist.c
 
-sam-buff.o: sam-buff.c ../local/include/xtend.h \
-  ../local/include/xtend-protos.h sam-buff.h sam.h dsv.h biolibc.h
+sam-buff.o: sam-buff.c sam-buff.h sam.h dsv.h biolibc.h
 	${CC} -c ${CFLAGS} sam-buff.c
 
-sam.o: sam.c ../local/include/xtend.h ../local/include/xtend-protos.h \
-  sam.h dsv.h biolibc.h
+sam.o: sam.c sam.h dsv.h biolibc.h
 	${CC} -c ${CFLAGS} sam.c
 
 vcf.o: vcf.c vcf.h dsv.h biolibc.h sam.h


### PR DESCRIPTION
Currently, the `libxtend` header files are hardcoded as dependencies in `Makefile.depend` and are expected to be in the following paths:

```
../local/include/xtend.h
../local/include/xtend-protos.h
```

This was problematic for me, as I installed `libxtend` globally to `/usr/local` (which is fairly standard). I'm not sure why they're included in this `Makefile.depend` anyways, as I think you should be expecting the user to install `libxtend` *before* attempting to install `biolibc`, and it would be good to allow the user to install it wherever they want, as long as it's in one of their "include" paths.

This pull request simply deletes `../local/include/xtend.h` and `../local/include/xtend-protos.h` from any target dependencies they were a part of